### PR TITLE
copy files from lib64 to lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ cd cpp-ethereum
 # make a build folder and enter into it
 mkdir -p build && cd build
 
+#make sure ../cpp-ethereum/build/libs has the files: libbinaryen.a, libmpir.a
+#copy these files from ../cpp-ethereum/build/deps/libs64 to ../cpp-ethereum/build/deps/lib
+cp -r deps/lib64/libbinaryen.a deps/lib/
+cp -r deps/lib64/libmpir.a deps/lib/
+
 # create build files and specify Ethereum installation folder
 cmake .. -DCMAKE_INSTALL_PREFIX=/opt/eth
 


### PR DESCRIPTION
Workaround for source compilation error - No rule to make target 'deps/lib/libbinaryen.a', needed by 'test/testeth'. Stop
copy files from deps/lib64 to deps/lib